### PR TITLE
chore: don't need to install hub cli

### DIFF
--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -17,22 +17,6 @@ jobs:
         with:
           python-version: "3.7"
 
-      - name: Install HUB CLI
-        run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-          test -d ~/.linuxbrew && eval $(~/.linuxbrew/bin/brew shellenv)
-          test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-          test -r ~/.bash_profile && echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.bash_profile
-          echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.profile
-          brew install hub
-
-      - name: Apply Configuration policy
-        run: |
-          test -d ~/.linuxbrew && eval $(~/.linuxbrew/bin/brew shellenv)
-          test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-          test -r ~/.bash_profile && echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.bash_profile
-          echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.profile
-
       - name: Update SC4S Version
         run: |
           ./sc4s_sync.sh

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 .DS_Store
 
 .idea/
+
+requirements_dev.txt


### PR DESCRIPTION
Hub CLI already exists in the Github Actions image: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md