### PR TITLE
fix: Bump sc4s/splunk versions

### DIFF
--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -1,6 +1,9 @@
 name: Check Splunk and SC4S Versions
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "0 05 * * SUN"
 
@@ -16,22 +19,6 @@ jobs:
         uses: actions/setup-python@v2.2.2
         with:
           python-version: "3.7"
-
-      - name: Install HUB CLI
-        run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-          test -d ~/.linuxbrew && eval $(~/.linuxbrew/bin/brew shellenv)
-          test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-          test -r ~/.bash_profile && echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.bash_profile
-          echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.profile
-          brew install hub
-
-      - name: Apply Configuration policy
-        run: |
-          test -d ~/.linuxbrew && eval $(~/.linuxbrew/bin/brew shellenv)
-          test -d /home/linuxbrew/.linuxbrew && eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)
-          test -r ~/.bash_profile && echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.bash_profile
-          echo "eval \$($(brew --prefix)/bin/brew shellenv)" >>~/.profile
 
       - name: Update SC4S Version
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 .DS_Store
 
 .idea/
+
+requirements-dev.txt

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,8 @@
+certifi==2021.10.8; python_version >= "3.7" and python_version < "4"
+charset-normalizer==2.0.7; python_version >= "3.7" and python_version < "4" and python_full_version >= "3.5.0"
+configparser==5.0.2; python_version >= "3.6"
+idna==3.3; python_version >= "3.7" and python_version < "4"
+packaging==21.0; python_version >= "3.6"
+pyparsing==2.4.7; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
+requests==2.28.1; python_version >= "3.7" and python_version < "4"
+urllib3==1.26.7; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4" or python_full_version >= "3.5.0" and python_version < "4" and python_version >= "3.7"


### PR DESCRIPTION
- chore: don't need to install hub cli
- fix: update sc4s/splunk versions
