### PR TITLE
feat: revert unreleased python39 splunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # addonfactory-test-matrix-action
 
-This GitHub Actions is used to prepare output variables that can be used to determine the correct flow of a CI workflow.
-
-The latest stable version is v1.10, please use it. Version v1.11 contains unreleased Splunk version which is not accessible by public.
+This Github Actions is used to prepare output variables that can be used to determine the correct flow of a CI workflow. 
 
 Using this approach an addon/connector to be tested can identify by feature flag which versions of Splunk should be tested. The tool is configured by a `.addonmatrix` file in the repo root. If no file is present all supported versions of Splunk will be tested.
 

--- a/action.yml
+++ b/action.yml
@@ -3,4 +3,4 @@ name: "Add on factory test matrix"
 description: "This tool automates the selection matrix dimensions"
 runs:
   using: "docker"
-  image: Dockerfile
+  image: docker://ghcr.io/splunk/addonfactory-test-matrix-action/addonfactory-test-matrix-action:v1.10.4

--- a/action.yml
+++ b/action.yml
@@ -3,4 +3,4 @@ name: "Add on factory test matrix"
 description: "This tool automates the selection matrix dimensions"
 runs:
   using: "docker"
-  image: docker://ghcr.io/splunk/addonfactory-test-matrix-action/addonfactory-test-matrix-action:v1.11.0
+  image: Dockerfile

--- a/addonfactory_test_matrix_action/main.py
+++ b/addonfactory_test_matrix_action/main.py
@@ -34,7 +34,7 @@ def _generate_supported_splunk(args, path):
     config.read(splunk_matrix)
     supported_splunk = []
     for section in config.sections():
-        if re.search(r"^\d+|unreleased-.*", section):
+        if re.search(r"^\d+", section):
             props = {}
             supported_splunk_string = config[section]["SUPPORTED"]
             eol = datetime.strptime(supported_splunk_string, "%Y-%m-%d").date()

--- a/config/splunk_matrix.conf
+++ b/config/splunk_matrix.conf
@@ -2,16 +2,6 @@
 LATEST = 9.1
 OLDEST = 8.2
 
-[unreleased-python3_9-a076ce4c50aa]
-VERSION = unreleased-python3_9-a076ce4c50aa
-BUILD = a076ce4c50aa
-SUPPORTED = 2035-07-06
-PYTHON3 = true
-PYTHON2 = false
-METRICS_MULTI = true
-INPUT_LOOKUP = true
-SWC = true
-
 [9.1]
 VERSION = 9.1.1
 BUILD = 64e843ea36b1


### PR DESCRIPTION
We found a way to include additional configuration in the job matrix (https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations), the workaround in this repository is not needed anymore.