### PR TITLE
chore: fail the workflow after unsuccessful requests

### DIFF
--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - run: ./sc4s_sync.sh
         with:
           python-version: 3.12
+      - run: ./sc4s_sync.sh
       - uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.SA_GPG_PRIVATE_KEY }}

--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - run: ./sc4s_sync.sh
+        with:
+          python-version: 3.12
       - uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.SA_GPG_PRIVATE_KEY }}
@@ -45,7 +47,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - run: ./splunk_sync.sh
+        with:
+          python-version: 3.12
+      - run: |
+          pip install -r requirements.txt
+          splunk_version=$(python splunk_matrix_update.py)
+          echo $splunk_version
       - uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.SA_GPG_PRIVATE_KEY }}

--- a/splunk_matrix_update.py
+++ b/splunk_matrix_update.py
@@ -10,6 +10,7 @@ from packaging import version
 def get_token():
     splunk_token_url = "https://auth.docker.io/token?service=registry.docker.io&scope=repository:splunk/splunk:pull"
     response = requests.get(splunk_token_url)
+    response.raise_for_status()
     response_json = json.loads(response.text)
     token = response_json["token"]
     return token
@@ -19,6 +20,7 @@ def get_images_list(token):
     headers = {"Authorization": f"Bearer {token}"}
     splunk_image_list_url = "https://registry.hub.docker.com/v2/splunk/splunk/tags/list"
     response = requests.get(splunk_image_list_url, headers=headers)
+    response.raise_for_status()
     response_json = json.loads(response.text)
     return response_json["tags"]
 
@@ -57,6 +59,7 @@ def get_image_digest(token, image):
         f"https://registry.hub.docker.com/v2/splunk/splunk/manifests/{image}"
     )
     response = requests.get(image_digest_url, headers=headers)
+    response.raise_for_status()
     if response.headers["Docker-Content-Digest"]:
         return response.headers["Docker-Content-Digest"]
     else:
@@ -71,6 +74,7 @@ def get_image_digest(token, image):
             )
         )
         response = requests.get(image_digest_url, headers=headers)
+        response.raise_for_status()
         return response.headers["Docker-Content-Digest"]
 
 

--- a/splunk_sync.sh
+++ b/splunk_sync.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# echo all the commands
-set -x
-
-pip install -r requirements.txt
-splunk_version=$(python splunk_matrix_update.py)
-echo $splunk_version


### PR DESCRIPTION
The Python script to update Splunk version was actually failing but we could not see that because it did not fail the pipeline. This PR fixes that.

https://github.com/splunk/addonfactory-test-matrix-action/actions/runs/10010033738/job/27670279550#step:4:54