### PR TITLE
fix: add new Splunk version 9.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@ The following example configuration file indicates a version of Splunk with "MET
 ```
 --splunkfeatures METRICS_MULTI
 ```
+
+# Development flow
+
+Once new version of Splunk or sc4s is released and PR with updates in SC4S_matrix.conf or splunk_matrix.conf is created, new configuration should be tested against TAs before the new release of action. 
+1. update the [action.yaml](https://github.com/splunk/addonfactory-test-matrix-action/blob/main/action.yml#L6) file - you need to configure it to use the Dockerfile directly. This ensures that the latest changes are included in the testing environment.
+2. Create a PR on [addonfactory-workflow-addon-release](https://github.com/splunk/addonfactory-workflow-addon-release)
+3. In this PR, modify the matrix step to reference the branch of `addonfactory-test-matrix-action` that is currently under test.
+4. Execute CI for several TAs with `build-test-release` workflow referencing created branch on `addonfactory-workflow-addon-release`
+5. After succesfull execution of tests, make a new fix release of `addonfactory-test-matrix-action` which will be automatically incorporated into latest `addonfactory-workflow-addon-release` workflow

--- a/action.yml
+++ b/action.yml
@@ -3,4 +3,4 @@ name: "Add on factory test matrix"
 description: "This tool automates the selection matrix dimensions"
 runs:
   using: "docker"
-  image: docker://ghcr.io/splunk/addonfactory-test-matrix-action/addonfactory-test-matrix-action:v2.1.4
+  image: Dockerfile

--- a/config/splunk_matrix.conf
+++ b/config/splunk_matrix.conf
@@ -1,6 +1,16 @@
 [GENERAL]
-LATEST = 9.2
+LATEST = 9.3
 OLDEST = 9.1
+
+[9.3]
+VERSION = 9.3.0
+BUILD = 51ccf43db5bd
+SUPPORTED = 2026-07-24
+PYTHON3 = true
+PYTHON2 = false
+SWC = true
+METRICS_MULTI = true
+INPUT_LOOKUP = true
 
 [9.2]
 VERSION = 9.2.2


### PR DESCRIPTION
Splunk 9.3 was released and image published on Dockerhub on 30.07.2024. 
CI is broken as of now so creating this PR manually.

Tests:

1. https://github.com/splunk/splunk-add-on-for-google-cloud-platform/runs/28181466354 - single failure, seems to be flaky. Also there is problem with representation of tests results in report when multiple markers are used.
2. https://github.com/splunk/splunk-add-on-for-mysql/pull/501/checks?check_run_id=28180829560 - all tests passed
3. https://github.com/splunk/splunk-add-on-for-servicenow/runs/28182090354 - failures in modinput, not related with Splunk update