### PR TITLE
fix: bump SC4S version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,4 +3,4 @@ name: "Add on factory test matrix"
 description: "This tool automates the selection matrix dimensions"
 runs:
   using: "docker"
-  image: docker://ghcr.io/splunk/addonfactory-test-matrix-action/addonfactory-test-matrix-action:v2.1.9
+  image: Dockerfile

--- a/config/SC4S_matrix.conf
+++ b/config/SC4S_matrix.conf
@@ -1,6 +1,6 @@
 #SC4S Major versions
 #
 [2]
-VERSION=3.30.1
+VERSION=3.32.1
 DOCKER_REGISTRY=ghcr.io/splunk/splunk-connect-for-syslog/container3
 


### PR DESCRIPTION
Tested: 

- [x] https://github.com/splunk/splunk-add-on-for-cisco-identity-services/actions/runs/11894063913/attempts/1#summary-33141579421 - two new failed TCs: `test_requirements_fields[sample_name::spgdi_cisco_ise.xml::host::cisco-ise-host-v3-150]` and `test_requirements_fields[sample_name::spgdi_cisco_ise.xml::host::cisco-ise-host-v3-113]`
- [x] https://github.com/splunk/splunk-add-on-for-salesforce/actions/runs/11894137167
- [x] https://github.com/splunk/splunk-add-on-for-cisco-esa/actions/runs/11895022833