### PR TITLE
feat: remove file-based input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,7 @@ jobs:
           git_committer_email: ${{ secrets.SA_GH_USER_EMAIL }}
           gpg_private_key: ${{ secrets.SA_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.SA_GPG_PASSPHRASE }}
+
   update-semver:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: build_release

--- a/README.md
+++ b/README.md
@@ -1,23 +1,18 @@
 # addonfactory-test-matrix-action
 
-This Github Actions is used to prepare output variables that can be used to determine the correct flow of a CI workflow. 
+This GitHub Actions is used to prepare output variables that can be used to determine the correct flow of a CI workflow. 
 
-Using this approach an addon/connector to be tested can identify by feature flag which versions of Splunk should be tested. The tool is configured by a `.addonmatrix` file in the repo root. If no file is present all supported versions of Splunk will be tested.
+Using this approach an add-on/connector to be tested can identify by feature flag which versions of Splunk should be tested.
 
 Using the current Support Policy Expiration dates versions of Splunk will be automatically removed and added in the future.
 
-The following example configuration file indicates a version of Splunk with "METRICS_MULTI" is required.
-
-```
---splunkfeatures METRICS_MULTI
-```
-
 # Development flow
 
-Once new version of Splunk or sc4s is released and PR with updates in SC4S_matrix.conf or splunk_matrix.conf is created, new configuration should be tested against TAs before the new release of action. 
-1. update the [action.yaml](https://github.com/splunk/addonfactory-test-matrix-action/blob/main/action.yml#L6) file - you need to configure it to use the Dockerfile directly. This ensures that the latest changes are included in the testing environment.
+Once new version of Splunk or SC4S is released and PR with updates in SC4S_matrix.conf or splunk_matrix.conf is created, new configuration should be tested against TAs before the new release of action.
+
+1. Update the [action.yaml](https://github.com/splunk/addonfactory-test-matrix-action/blob/main/action.yml#L6) file - you need to configure it to use the Dockerfile directly. This ensures that the latest changes are included in the testing environment.
 2. Create a PR on [addonfactory-workflow-addon-release](https://github.com/splunk/addonfactory-workflow-addon-release)
 3. In this PR, modify the matrix step to reference the branch of `addonfactory-test-matrix-action` that is currently under test.
 4. Execute CI for several TAs with `build-test-release` workflow referencing created branch on `addonfactory-workflow-addon-release`
-5. After succesfull execution of tests, make a new fix release of `addonfactory-test-matrix-action` which will be automatically incorporated into latest `addonfactory-workflow-addon-release` workflow
-6. *Only for changes in the `config/splunk_matrix.conf`: Follow the instructions from [Runbook to creating and publishing docker images used in reusable workflow](https://github.com/splunk/addonfactory-workflow-addon-release/blob/main/runbooks/addonfactory-workflow-addon-release-docker-images.md#runbook-to-publish-multiple-images-of-different-linux-flavors-and-versions-for-scripted-inputs-tests) to create and publish Splunk images for scripted inputs tests based on the updates in the matrix coniguration. 
+5. After successful execution of tests, make a new fix release of `addonfactory-test-matrix-action` which will be automatically incorporated into latest `addonfactory-workflow-addon-release` workflow
+6. *Only for changes in the `config/splunk_matrix.conf`: Follow the instructions from [Runbook to creating and publishing docker images used in reusable workflow](https://github.com/splunk/addonfactory-workflow-addon-release/blob/main/runbooks/addonfactory-workflow-addon-release-docker-images.md#runbook-to-publish-multiple-images-of-different-linux-flavors-and-versions-for-scripted-inputs-tests) to create and publish Splunk images for scripted inputs tests based on the updates in the matrix coniguration.

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,5 @@
-# action.yml
-name: "Add on factory test matrix"
+name: "addonfactory-test-matrix-action"
 description: "This tool automates the selection matrix dimensions"
 runs:
   using: "docker"
-  image: docker://ghcr.io/splunk/addonfactory-test-matrix-action/addonfactory-test-matrix-action:v2.1.12
+  image: "Dockerfile"

--- a/addonfactory_test_matrix_action/main.py
+++ b/addonfactory_test_matrix_action/main.py
@@ -132,7 +132,10 @@ def main():
         help="Include unsupported SC4S versions",
     )
     parser.add_argument(
-        "--splunkfeatures", type=str, default="METRICS_MULTI,PYTHON3", help="Required Features"
+        "--splunkfeatures",
+        type=str,
+        default="METRICS_MULTI,PYTHON3",
+        help="Required Features",
     )
 
     args = parser.parse_args()

--- a/addonfactory_test_matrix_action/main.py
+++ b/addonfactory_test_matrix_action/main.py
@@ -9,13 +9,6 @@ from datetime import datetime
 from pathlib import Path
 
 
-class LoadFromFile(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        with values as f:
-            # parse arguments in the file and store them in the target namespace
-            parser.parse_args(f.read().split(), namespace)
-
-
 def has_features(features, section):
     if features is not None:
         for feature in features.split(","):
@@ -128,19 +121,18 @@ def _generate_supported_vendors(args, path):
 def main():
     parser = argparse.ArgumentParser(description="Determine support matrix")
 
-    parser.add_argument("--file", type=open, action=LoadFromFile)
     parser.add_argument(
         "--unsupportedSplunk",
         action="store_true",
-        help="include unsupported Splunk versions",
+        help="Include unsupported Splunk versions",
     )
     parser.add_argument(
         "--unsupportedSC4S",
         action="store_true",
-        help="include unsupported SC4S versions",
+        help="Include unsupported SC4S versions",
     )
     parser.add_argument(
-        "--splunkfeatures", type=str, default=None, help="Required Features"
+        "--splunkfeatures", type=str, default="METRICS_MULTI,PYTHON3", help="Required Features"
     )
 
     args = parser.parse_args()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,8 +16,4 @@
 #   ######################################################################## 
 set -e
 . /venv/bin/activate
-if [ -f $INPUT_APP_PATH ]
-then 
-    f="--file=.addonmatrix"
-fi
-python /addonfactory_test_matrix_action/main.py $f $@
+python /addonfactory_test_matrix_action/main.py $@


### PR DESCRIPTION
This PR removes necessity to have a `.addonmatrix` file in the root of the directory to configure which versions of Splunk need to be tested.

I do not believe that file was ever changed so there is no need as of now to provide it as an input parameter in `action.yml` but this option is on the table in case it will be needed in the future.

I believe it's safe to mark it as a breaking change in case someone uses non-default value in `.addonmatrix` file. Please reach out and we will expose `--splunkfeatures` parameter through `action.yml` file. 

BREAKING CHANGE: remove file-based input