### PR TITLE
fix: optional features

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,3 @@ inputs:
 runs:
   using: "docker"
   image: "Dockerfile"
-  args:
-    - --features
-    - ${{ inputs.features }}

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     type: string
 runs:
   using: "docker"
-  image: "docker://ghcr.io/splunk/addonfactory-test-matrix-action/addonfactory-test-matrix-action:v3.1.0"
+  image: "Dockerfile"
   args:
     - --features
     - ${{ inputs.features }}

--- a/addonfactory_test_matrix_action/main.py
+++ b/addonfactory_test_matrix_action/main.py
@@ -123,6 +123,7 @@ def main():
     parser.add_argument(
         "--features",
         type=str,
+        default=None,
         help="Comma separated list of features",
     )
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,4 +16,9 @@
 #   ######################################################################## 
 set -e
 . /venv/bin/activate
-python /addonfactory_test_matrix_action/main.py $@
+
+if [ -n "$INPUT_FEATURES" ] && [ "$INPUT_FEATURES" != "" ]; then
+    python /addonfactory_test_matrix_action/main.py --features "$INPUT_FEATURES"
+else
+    python /addonfactory_test_matrix_action/main.py
+fi


### PR DESCRIPTION
In order to be backward compatible `features` parameter is optional.

Tests:
https://github.com/splunk/pytest-splunk-addon/actions/runs/16900588090/job/47880133437