### PR TITLE
fix: bump SC4S version

### DIFF
--- a/config/SC4S_matrix.conf
+++ b/config/SC4S_matrix.conf
@@ -1,6 +1,6 @@
 #SC4S Major versions
 #
 [2]
-VERSION=3.39.0
+VERSION=3.40.0
 DOCKER_REGISTRY=ghcr.io/splunk/splunk-connect-for-syslog/container3
 


### PR DESCRIPTION
Validation for the SC4S matrix version update is complete.

Tested the changes from the addonfactory-test-matrix-action PR by running the reusable workflow against the Splunk Add-on for Apache Web Server.

The test workflow passed successfully, and the logs confirm that the new SC4S matrix version was correctly picked up and used by the test matrix.

Test Run link - https://github.com/splunk/splunk-add-on-for-apache-web-server/actions/runs/23483317665/