### PR TITLE
fix: downgrade SC4S to working version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,4 +7,4 @@ inputs:
     type: string
 runs:
   using: "docker"
-  image: 'docker://ghcr.io/splunk/addonfactory-test-matrix-action/addonfactory-test-matrix-action:v3.1.7'
+  image: 'Dockerfile'

--- a/config/SC4S_matrix.conf
+++ b/config/SC4S_matrix.conf
@@ -1,6 +1,6 @@
 #SC4S Major versions
 #
 [2]
-VERSION=3.42.0
+VERSION=3.37.0
 DOCKER_REGISTRY=ghcr.io/splunk/splunk-connect-for-syslog/container3
 

--- a/config/SC4S_matrix.conf
+++ b/config/SC4S_matrix.conf
@@ -1,6 +1,6 @@
 #SC4S Major versions
 #
 [2]
-VERSION=3.37.0
+VERSION=3.40.0
 DOCKER_REGISTRY=ghcr.io/splunk/splunk-connect-for-syslog/container3
 


### PR DESCRIPTION
SC4S v3.41 introduced regression causing failures on TAs side.
Downgrading to v3.40 until the issue is resolved.
More details: https://splunk.slack.com/archives/CRTNPEZ4M/p1781875400460099?thread_ts=1781622466.333719&cid=CRTNPEZ4M